### PR TITLE
Add extra step to restart pulp_resource_manager.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,9 @@ Install ``pulp_example`` from source
 6)  pulp-manager makemigrations pulp\_example
 7)  pulp-manager migrate pulp\_example
 8)  django-admin runserver
-9)  sudo systemctl restart pulp\_worker@1
-10) sudo systemctl restart pulp\_worker@2
+9)  sudo systemctl restart pulp\_resource\_manager
+10) sudo systemctl restart pulp\_worker@1
+11) sudo systemctl restart pulp\_worker@2
 
 Install ``pulp_example`` from PyPI
 ----------------------------------
@@ -50,8 +51,9 @@ Install ``pulp_example`` from PyPI
 4) pulp-manager makemigrations pulp\_example
 5) pulp-manager migrate pulp\_example
 6) django-admin runserver
-7) sudo systemctl restart pulp\_worker@1
-8) sudo systemctl restart pulp\_worker@2
+7) sudo systemctl restart pulp\_resource\_manager
+8) sudo systemctl restart pulp\_worker@1
+9) sudo systemctl restart pulp\_worker@2
 
 Create a repository ``foo``
 ---------------------------


### PR DESCRIPTION
After a fresh installation the current set of steps work properly to
run Pulp. However, after a reboot of the machine running Pulp, it is
necessary to restart the service, `pulp_resource_manager` to be able to
restart the workers properly.